### PR TITLE
Expose cloudwatch startTime, startTime should be in UTC

### DIFF
--- a/src/chai/cloudwatch.test.ts
+++ b/src/chai/cloudwatch.test.ts
@@ -71,18 +71,18 @@ describe('cloudwatch', () => {
       filterLogEvents.mockReturnValue(Promise.resolve({ events: ['event'] }));
       epochDateMinusHours.mockReturnValue(11 * 60 * 60 * 1000);
 
-      const props = { region, function: functionName };
-      await chai.expect(props).to.have.log(pattern);
+      const propsNoTime = { region, function: functionName };
+      await chai.expect(propsNoTime).to.have.log(pattern);
 
       expect(filterLogEvents).toHaveBeenCalledTimes(1);
       expect(filterLogEvents).toHaveBeenCalledWith(
-        props.region,
-        props.function,
+        propsNoTime.region,
+        propsNoTime.function,
         11 * 60 * 60 * 1000,
         pattern,
       );
       expect(verifyProps).toHaveBeenCalledTimes(1);
-      expect(verifyProps).toHaveBeenCalledWith({ ...props, pattern }, [
+      expect(verifyProps).toHaveBeenCalledWith({ ...propsNoTime, pattern }, [
         'region',
         'function',
         'startTime',

--- a/src/chai/cloudwatch.ts
+++ b/src/chai/cloudwatch.ts
@@ -1,4 +1,4 @@
-import { verifyProps } from '../common';
+import { epochDateMinusHours, verifyProps } from '../common';
 import { expectedProps, ICloudwatchProps } from '../common/cloudwatch';
 import { filterLogEvents } from '../utils/cloudwatch';
 import { wrapWithRetries } from './utils';
@@ -8,8 +8,17 @@ const attemptCloudwatch = async function(this: any, pattern: string) {
 
   verifyProps({ ...props, pattern }, expectedProps);
 
-  const { region, function: functionName } = props;
-  const { events } = await filterLogEvents(region, functionName, pattern);
+  const {
+    region,
+    function: functionName,
+    startTime = epochDateMinusHours(1),
+  } = props;
+  const { events } = await filterLogEvents(
+    region,
+    functionName,
+    startTime,
+    pattern,
+  );
   const found = events.length > 0;
 
   return {

--- a/src/common/cloudwatch.ts
+++ b/src/common/cloudwatch.ts
@@ -2,6 +2,7 @@ import { ICommonProps } from './';
 
 export interface ICloudwatchProps extends ICommonProps {
   function: string;
+  startTime?: number;
 }
 
-export const expectedProps = ['region', 'function', 'pattern'];
+export const expectedProps = ['region', 'function', 'startTime', 'pattern'];

--- a/src/common/index.test.ts
+++ b/src/common/index.test.ts
@@ -1,4 +1,4 @@
-import { sleep, verifyProps, epochDateMinusHours } from './';
+import { epochDateMinusHours, sleep, verifyProps } from './';
 
 jest.useFakeTimers();
 

--- a/src/common/index.test.ts
+++ b/src/common/index.test.ts
@@ -1,4 +1,4 @@
-import { sleep, verifyProps } from './';
+import { sleep, verifyProps, epochDateMinusHours } from './';
 
 jest.useFakeTimers();
 
@@ -24,6 +24,16 @@ describe('common', () => {
 
     test('should not throw error on no missing prop', () => {
       expect(() => verifyProps({ id: 'value' }, ['id'])).not.toThrow();
+    });
+  });
+
+  describe('epochDateMinusHours', () => {
+    jest.spyOn(Date, 'parse').mockImplementation(() => 12 * 60 * 60 * 1000);
+
+    test('test implementation', () => {
+      const actual = epochDateMinusHours(1);
+
+      expect(actual).toEqual(11 * 60 * 60 * 1000);
     });
   });
 });

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -16,3 +16,10 @@ export const verifyProps = (props: any, expectedProps: string[]) => {
     }
   }
 };
+
+const hoursToMilliseconds = (hours: number) => hours * 60 * 60 * 1000;
+
+export const epochDateMinusHours = (hours: number) => {
+  const now = new Date();
+  return Date.parse(now.toUTCString()) - hoursToMilliseconds(hours);
+};

--- a/src/jest/README.md
+++ b/src/jest/README.md
@@ -98,6 +98,7 @@ expect.assertions(1); // makes sure the assertion was called
 await expect({
   region: 'us-east-1',
   function: 'functionName',
+  startTime: 0 /* optional (millis since epoch in UTC, defaults to now-1 hour) */,
   timeout: 0 /* optional (defaults to 2500) */,
   pollEvery: 0 /* optional (defaults to 500) */,
 }).toHaveLog(

--- a/src/jest/cloudwatch.test.ts
+++ b/src/jest/cloudwatch.test.ts
@@ -75,19 +75,18 @@ describe('cloudwatch matchers', () => {
 
       epochDateMinusHours.mockReturnValue(11 * 60 * 60 * 1000);
 
-      const props = { region, function: functionName };
-      console.log(JSON.stringify(props));
-      await toHaveLog.bind(matcherUtils)(props, pattern);
+      const propsNoTime = { region, function: functionName };
+      await toHaveLog.bind(matcherUtils)(propsNoTime, pattern);
 
       expect(filterLogEvents).toHaveBeenCalledTimes(1);
       expect(filterLogEvents).toHaveBeenCalledWith(
-        props.region,
-        props.function,
+        propsNoTime.region,
+        propsNoTime.function,
         11 * 60 * 60 * 1000,
         pattern,
       );
       expect(verifyProps).toHaveBeenCalledTimes(1);
-      expect(verifyProps).toHaveBeenCalledWith({ ...props, pattern }, [
+      expect(verifyProps).toHaveBeenCalledWith({ ...propsNoTime, pattern }, [
         'region',
         'function',
         'startTime',

--- a/src/jest/cloudwatch.ts
+++ b/src/jest/cloudwatch.ts
@@ -1,5 +1,5 @@
 import { EOL } from 'os';
-import { verifyProps } from '../common';
+import { epochDateMinusHours, verifyProps } from '../common/index';
 import { expectedProps, ICloudwatchProps } from '../common/cloudwatch';
 import { filterLogEvents } from '../utils/cloudwatch';
 
@@ -9,8 +9,11 @@ export const toHaveLog = async function(
   pattern: string,
 ) {
   verifyProps({ ...props, pattern }, expectedProps);
-
-  const { region, function: functionName } = props;
+  const {
+    region,
+    function: functionName,
+    startTime = epochDateMinusHours(1),
+  } = props;
 
   try {
     const printFunctionName = this.utils.printExpected(functionName);
@@ -20,7 +23,12 @@ export const toHaveLog = async function(
     const notHint = this.utils.matcherHint('.not.toHaveLog') + EOL + EOL;
     const hint = this.utils.matcherHint('.toHaveLog') + EOL + EOL;
 
-    const { events } = await filterLogEvents(region, functionName, pattern);
+    const { events } = await filterLogEvents(
+      region,
+      functionName,
+      startTime,
+      pattern,
+    );
     const found = events.length > 0;
     if (found) {
       // matching log found

--- a/src/jest/cloudwatch.ts
+++ b/src/jest/cloudwatch.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'os';
-import { epochDateMinusHours, verifyProps } from '../common/index';
 import { expectedProps, ICloudwatchProps } from '../common/cloudwatch';
+import { epochDateMinusHours, verifyProps } from '../common/index';
 import { filterLogEvents } from '../utils/cloudwatch';
 
 export const toHaveLog = async function(

--- a/src/utils/cloudwatch.test.ts
+++ b/src/utils/cloudwatch.test.ts
@@ -15,8 +15,6 @@ jest.mock('aws-sdk', () => {
   return { CloudWatchLogs };
 });
 
-jest.spyOn(Date, 'now').mockImplementation(() => 12 * 60 * 60 * 1000);
-
 describe('cloudwatch utils', () => {
   const AWS = require('aws-sdk');
   const cloudWatchLogs = AWS.CloudWatchLogs;
@@ -82,8 +80,14 @@ describe('cloudwatch utils', () => {
 
       jest.clearAllMocks();
 
+      const startTime = 12 * 60 * 60 * 1000;
       const filterPattern = 'filterPattern';
-      const actual = await getEvents(region, functionName, filterPattern);
+      const actual = await getEvents(
+        region,
+        functionName,
+        startTime,
+        filterPattern,
+      );
 
       expect(cloudWatchLogs).toHaveBeenCalledTimes(1);
       expect(cloudWatchLogs).toHaveBeenCalledWith({ region });
@@ -93,7 +97,7 @@ describe('cloudwatch utils', () => {
         interleaved: true,
         limit: 1,
         logGroupName,
-        startTime: 11 * 60 * 60 * 1000,
+        startTime,
       });
       expect(actual).toEqual({ events });
     });
@@ -105,8 +109,14 @@ describe('cloudwatch utils', () => {
 
       jest.clearAllMocks();
 
+      const startTime = 12 * 60 * 60 * 1000;
       const filterPattern = 'filterPattern';
-      const actual = await getEvents(region, functionName, filterPattern);
+      const actual = await getEvents(
+        region,
+        functionName,
+        startTime,
+        filterPattern,
+      );
 
       expect(actual).toEqual({ events: [] });
     });

--- a/src/utils/cloudwatch.ts
+++ b/src/utils/cloudwatch.ts
@@ -2,17 +2,15 @@ import AWS = require('aws-sdk');
 
 const getLogGroupName = (functionName: string) => `/aws/lambda/${functionName}`;
 
-const hoursToMilliseconds = (hours: number) => hours * 60 * 60 * 1000;
-
 export const filterLogEvents = async (
   region: string,
   functionName: string,
+  startTime: number,
   pattern: string,
 ) => {
   const cloudWatchLogs = new AWS.CloudWatchLogs({ region });
   const logGroupName = getLogGroupName(functionName);
   const filterPattern = `"${pattern}"`; // enclose with "" to support special characters
-  const startTime = Date.now() - hoursToMilliseconds(1);
 
   const { events = [] } = await cloudWatchLogs
     .filterLogEvents({


### PR DESCRIPTION
This PR is intended to give people the ability to pass in a startTime to the toHaveLog method.  This gives users of the library more control of the time frame they are searching.

Also, there is a small bug fix in how the default cloudwatch startTime was calculated.  It should be in UTC time, rather than local time.