### PR TITLE
feat: cloudwatch json pattern matching

### DIFF
--- a/src/chai/README.md
+++ b/src/chai/README.md
@@ -99,6 +99,7 @@ await expect({
   pollEvery: 0 /* optional (defaults to 500) */,
 }).to.have.log(
   'some message written to log' /* a pattern to match against log messages */,
+  {isPatternMetricFilterForJSON: false} /* set to true (default = false) if you are using metric filters to match terms from JSON log events */
 );
 ```
 

--- a/src/chai/cloudwatch.ts
+++ b/src/chai/cloudwatch.ts
@@ -1,9 +1,17 @@
 import { epochDateMinusHours, verifyProps } from '../common';
-import { expectedProps, ICloudwatchProps } from '../common/cloudwatch';
+import {
+  expectedProps,
+  ICloudwatchProps,
+  ToHaveLogOptions,
+} from '../common/cloudwatch';
 import { filterLogEvents, getLogGroupName } from '../utils/cloudwatch';
 import { wrapWithRetries } from './utils';
 
-const attemptCloudwatch = async function (this: any, pattern: string) {
+const attemptCloudwatch = async function (
+  this: any,
+  pattern: string,
+  { isPatternMetricFilterForJSON = false }: ToHaveLogOptions = {},
+) {
   const props = this._obj as ICloudwatchProps;
 
   verifyProps({ ...props, pattern }, expectedProps);
@@ -20,6 +28,7 @@ const attemptCloudwatch = async function (this: any, pattern: string) {
     logGroupName || getLogGroupName(functionName || ''),
     startTime,
     pattern,
+    isPatternMetricFilterForJSON ?? false,
   );
   const found = events.length > 0;
 

--- a/src/chai/index.ts
+++ b/src/chai/index.ts
@@ -9,13 +9,14 @@ import kinesis from './kinesis';
 import s3 from './s3';
 import sqs from './sqs';
 import stepFunctions from './stepFunctions';
+import { ToHaveLogOptions } from '../common/cloudwatch';
 
 declare global {
   namespace Chai {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Assertion {
       response: (expected: IExpectedResponse) => Assertion;
-      log: (pattern: string) => Assertion;
+      log: (pattern: string, options?: ToHaveLogOptions) => Assertion;
       item: (
         key: AWS.DynamoDB.DocumentClient.Key,
         expectedItem?: AWS.DynamoDB.DocumentClient.AttributeMap,

--- a/src/common/cloudwatch.ts
+++ b/src/common/cloudwatch.ts
@@ -6,4 +6,8 @@ export interface ICloudwatchProps extends ICommonProps {
   logGroupName?: string;
 }
 
+export interface ToHaveLogOptions {
+  isPatternMetricFilterForJSON?: boolean;
+}
+
 export const expectedProps = ['region', 'pattern'];

--- a/src/jest/README.md
+++ b/src/jest/README.md
@@ -103,6 +103,7 @@ await expect({
   pollEvery: 0 /* optional (defaults to 500) */,
 }).toHaveLog(
   'some message written to log' /* a pattern to match against log messages */,
+  {isPatternMetricFilterForJSON: false} /* set to true (default = false) if you are using metric filters to match terms from JSON log events */
 );
 ```
 

--- a/src/jest/cloudwatch.ts
+++ b/src/jest/cloudwatch.ts
@@ -1,5 +1,9 @@
 import { EOL } from 'os';
-import { expectedProps, ICloudwatchProps } from '../common/cloudwatch';
+import {
+  expectedProps,
+  ICloudwatchProps,
+  ToHaveLogOptions,
+} from '../common/cloudwatch';
 import { epochDateMinusHours, verifyProps } from '../common/index';
 import { filterLogEvents, getLogGroupName } from '../utils/cloudwatch';
 
@@ -7,6 +11,7 @@ export const toHaveLog = async function (
   this: jest.MatcherUtils,
   props: ICloudwatchProps,
   pattern: string,
+  { isPatternMetricFilterForJSON = false }: ToHaveLogOptions = {},
 ) {
   verifyProps({ ...props, pattern }, expectedProps);
   const {
@@ -31,6 +36,7 @@ export const toHaveLog = async function (
       logGroupName || getLogGroupName(functionName || ''),
       startTime,
       pattern,
+      isPatternMetricFilterForJSON ?? false,
     );
     const found = events.length > 0;
     if (found) {

--- a/src/utils/cloudwatch.ts
+++ b/src/utils/cloudwatch.ts
@@ -8,9 +8,10 @@ export const filterLogEvents = async (
   logGroupName: string,
   startTime: number,
   pattern: string,
+  isPatternMetricFilterForJSON: boolean,
 ) => {
   const cloudWatchLogs = new AWS.CloudWatchLogs({ region });
-  const filterPattern = `"${pattern}"`; // enclose with "" to support special characters
+  const filterPattern = isPatternMetricFilterForJSON ? pattern : `"${pattern}"`; // enclose with "" to support special characters
 
   const { events = [] } = await cloudWatchLogs
     .filterLogEvents({


### PR DESCRIPTION
There was an issue using json pattern matching filters for cloudwatch metrics as this library was wrapping all patterns in double quotes. I have added a way around this using a boolean flag to determine whether your pattern is for json logs.

