### PR TITLE
fix!: don't quote CloudWatch filter pattern

### DIFF
--- a/src/utils/cloudwatch.test.ts
+++ b/src/utils/cloudwatch.test.ts
@@ -92,7 +92,7 @@ describe('cloudwatch utils', () => {
       expect(cloudWatchLogs).toHaveBeenCalledWith({ region });
       expect(filterLogEvents).toHaveBeenCalledTimes(1);
       expect(filterLogEvents).toHaveBeenCalledWith({
-        filterPattern: `"${filterPattern}"`,
+        filterPattern,
         interleaved: true,
         limit: 1,
         logGroupName,

--- a/src/utils/cloudwatch.ts
+++ b/src/utils/cloudwatch.ts
@@ -7,10 +7,9 @@ export const filterLogEvents = async (
   region: string,
   logGroupName: string,
   startTime: number,
-  pattern: string,
+  filterPattern: string,
 ) => {
   const cloudWatchLogs = new AWS.CloudWatchLogs({ region });
-  const filterPattern = `"${pattern}"`; // enclose with "" to support special characters
 
   const { events = [] } = await cloudWatchLogs
     .filterLogEvents({


### PR DESCRIPTION
Other way to fix https://github.com/erezrokah/aws-testing-library/pull/696.

This is a breaking change so will be released as a new major version bump