### PR TITLE
removing dependency on filter-obj

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,7 @@
 /* eslint-env node */
-const esModules = ['filter-obj'].join('|');
 
 module.exports = {
   roots: ['<rootDir>/src'],
   preset: 'ts-jest/presets/js-with-ts',
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
-  transformIgnorePatterns: [`node_modules/(?!${esModules})`],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
+        "aws-testing-library": "^4.0.6",
         "chai": "^4.2.0",
         "eslint": "^8.0.0",
         "eslint-config-prettier": "^8.0.0",
@@ -2083,6 +2084,22 @@
       "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/aws-testing-library": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/aws-testing-library/-/aws-testing-library-4.0.6.tgz",
+      "integrity": "sha512-D2pMJug6ObLF7WbA/Qv/qRnWlp2CyScGybetZc2ihQ7EoOGE6MFaortXcnk7eLGqb9MDgcpqgsESkzSt81uY4A==",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "^2.678.0",
+        "axios": "^0.27.0",
+        "filter-obj": "^3.0.0",
+        "jest-diff": "^29.0.0",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
       }
     },
     "node_modules/axios": {
@@ -8439,6 +8456,19 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
           "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
         }
+      }
+    },
+    "aws-testing-library": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/aws-testing-library/-/aws-testing-library-4.0.6.tgz",
+      "integrity": "sha512-D2pMJug6ObLF7WbA/Qv/qRnWlp2CyScGybetZc2ihQ7EoOGE6MFaortXcnk7eLGqb9MDgcpqgsESkzSt81uY4A==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.678.0",
+        "axios": "^0.27.0",
+        "filter-obj": "^3.0.0",
+        "jest-diff": "^29.0.0",
+        "uuid": "^9.0.0"
       }
     },
     "axios": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "aws-sdk": "^2.678.0",
     "axios": "^0.27.0",
-    "filter-obj": "^3.0.0",
     "jest-diff": "^29.0.0",
     "uuid": "^9.0.0"
   },

--- a/src/common/dynamoDb.ts
+++ b/src/common/dynamoDb.ts
@@ -1,4 +1,3 @@
-import filterObject from 'filter-obj';
 import { AttributeMap } from 'aws-sdk/clients/dynamodb';
 import { ICommonProps } from './';
 
@@ -7,6 +6,29 @@ export interface IDynamoDbProps extends ICommonProps {
 }
 
 export const expectedProps = ['region', 'table', 'key'];
+
+type predicate =  (key: any, value: any, object: any) => boolean | Array<any>
+
+const filterObject = (
+  object: AttributeMap,
+  predicate: predicate,
+) => {
+  const result = {};
+  const isArray = Array.isArray(predicate);
+
+  for (const [key, value] of Object.entries(object)) {
+    if (isArray ? predicate.includes(key) : predicate(key, value, object)) {
+      Object.defineProperty(result, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  return result;
+};
 
 export const removeKeysFromItemForNonStrictComparison = (
   received: AttributeMap,


### PR DESCRIPTION
removing dependency on filter-obj

dependency has been causing problems since the >4.0.0 update