### PR TITLE
chore: Use GitHub App token and OIDC for release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,11 +6,20 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: GoogleCloudPlatform/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           release-type: node
           package-name: aws-testing-library
       - uses: actions/checkout@v6
@@ -24,7 +33,5 @@ jobs:
       - name: Install core dependencies
         run: npm ci --no-audit
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --provenance --access public
         if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permissions: >-
+            contents:write,
+            pull-requests:write
       - uses: GoogleCloudPlatform/release-please-action@v4
         id: release
         with:


### PR DESCRIPTION
## Summary
- Switch release workflow from personal access token to GitHub App token (using `APP_ID` and `APP_PRIVATE_KEY` secrets) and remove `NPM_TOKEN` in favor of OIDC provenance publishing.

## Test plan
- [x] Verify release-please creates release PRs using the app token
- [x] Verify npm publish succeeds with OIDC provenance