### PR TITLE
chore: Fix release-please workflow warnings

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,17 +12,15 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permissions: >-
-            contents:write,
-            pull-requests:write
+          permission-contents: write
+          permission-pull-requests: write
       - uses: GoogleCloudPlatform/release-please-action@v4
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           release-type: node
-          package-name: aws-testing-library
       - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Replace deprecated `app-id` with `client-id` (requires new `APP_CLIENT_ID` secret)
- Replace invalid `permissions` input with `permission-contents` and `permission-pull-requests`
- Remove `package-name` input which is not valid for release-please-action v4